### PR TITLE
コマンドの登録が上書きされて一部コマンドが使えなかった問題の修正

### DIFF
--- a/src/main/java/work/saladbowl/disgot/discord/discmain.java
+++ b/src/main/java/work/saladbowl/disgot/discord/discmain.java
@@ -10,6 +10,7 @@ import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.*;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 
+import net.dv8tion.jda.api.requests.restaction.CommandListUpdateAction;
 import work.saladbowl.disgot.Config;
 
 public class discmain{
@@ -29,6 +30,8 @@ public class discmain{
             // 参加しているサーバーを ID から取得
             Guild guild = jda.getGuildById(Config.SERVER_ID);
 
+            CommandListUpdateAction command = guild.updateCommands();
+
             // 登録するコマンドを作成
             // プレイヤー数のコマンド
             SlashCommandData playerList = Commands.slash("playerlist", "サーバー内の人数を取得するコード");
@@ -36,18 +39,14 @@ public class discmain{
                     .addOptions(
                             new OptionData(OptionType.STRING, "id", "マインクラフトのIDを記入してください", true)
                     );
-
-            guild.updateCommands()
-                    .addCommands(playerList)
-                    .addCommands(playerInfo)
-                    .queue();
+            command = command.addCommands(playerList).addCommands(playerInfo);
 
             if (Config.WHITELIST_JG_BOOL && Config.WHITELIST_JG_TYPE.equals("CMD")) {
                 SlashCommandData joinGame = Commands.slash("joingame", "Minecraftサーバーに参加するためのコマンド")
                         .addOptions(
                                 new OptionData(OptionType.STRING, "mcid", "マインクラフトのIDを記入してください", true)
                         );
-                guild.updateCommands().addCommands(joinGame).queue();
+                command = command.addCommands(joinGame);
             }
             if (Config.WHITELIST_CMD_BOOL) {
                 // ホワイトリストに追加するコマンド
@@ -63,8 +62,9 @@ public class discmain{
                                                 new OptionData(OptionType.STRING, "id", "マインクラフトまたはDiscordのIDを記載するところです", true)
                                         )
                         );
-                guild.updateCommands().addCommands(addWhitelist).queue();
+                command = command.addCommands(addWhitelist);
             }
+            command.queue();
         }catch (InterruptedException e){
             e.printStackTrace();
         }


### PR DESCRIPTION
コマンドの登録が上書きされて一部コマンドが使えなかった問題を修正しました。
動くかの検証はしてないけど同じやり方でやったとき動いたんで動くでしょう。きっと。

そういえばguild.updateCommands()をjda.updateCommands()にしてもいい気がします
それによる弊害としては
- 別のMC鯖で同じBotで別のDiscord鯖だった場合(?)にうまく動いていた...かもしれない(?)のがコマンドの登録がおかしくなる
  (同じDiscord鯖だった場合は関係なくおかしくなります
- Botが入ってる鯖全てにコマンドが設定される